### PR TITLE
Store failed fetches as null in cache instead of dummy value

### DIFF
--- a/api.tsx
+++ b/api.tsx
@@ -7,7 +7,7 @@
 import { Track } from "plugins/spotifyControls/SpotifyStore";
 
 const baseUrlLrclib = "https://lrclib.net/api/get";
-const LyricsCache = new Map<string, SyncedLyrics[]>();
+const LyricsCache = new Map<string, SyncedLyrics[] | null>();
 
 export interface SyncedLyrics {
     id: number;
@@ -66,7 +66,7 @@ export async function getLyrics(track: Track): Promise<SyncedLyrics[] | null> {
 
     const lyrics = await fetchLyrics(track);
     if (!lyrics) {
-        LyricsCache.set(cacheKey, [{ id: 0, time: 0, text: "No lyrics found", lrcTime: "[00:00.00]" }]);
+        LyricsCache.set(cacheKey, null);
         return null;
     }
     LyricsCache.set(cacheKey, lyrics);

--- a/api.tsx
+++ b/api.tsx
@@ -58,7 +58,6 @@ async function fetchLyrics(track: Track): Promise<SyncedLyrics[] | null> {
 
 
 export async function getLyrics(track: Track): Promise<SyncedLyrics[] | null> {
-    console.log("getLyrics", track);
     const cacheKey = track.id;
     if (LyricsCache.has(cacheKey)) {
         return LyricsCache.get(cacheKey)!;


### PR DESCRIPTION
Prevents the lyric modal from being opened and showing dummy data when no lyrics are available
![image](https://github.com/user-attachments/assets/84569ea3-90a9-44ce-906a-2ee61a375919)
