### PR TITLE
Dim colours of timestamps and the note when no lyrics are found

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -6,13 +6,22 @@
 
 import "./styles.css";
 
-import { Settings } from "@api/Settings";
+import { definePluginSettings, Settings } from "@api/Settings";
 import ErrorBoundary from "@components/ErrorBoundary";
 import { Devs } from "@utils/constants";
-import definePlugin from "@utils/types";
+import definePlugin, { OptionType, } from "@utils/types";
 import { Player } from "plugins/spotifyControls/PlayerComponent";
 
 import { Lyrics } from "./lyrics";
+
+
+export const settings = definePluginSettings({
+    ShowMusicNoteOnNoLyrics: {
+        description: "Show a music note icon when no lyrics are found",
+        type: OptionType.BOOLEAN,
+        default: true,
+    },
+});
 
 
 export default definePlugin({
@@ -49,4 +58,5 @@ export default definePlugin({
             </>
         );
     },
+    settings,
 });

--- a/lyrics.tsx
+++ b/lyrics.tsx
@@ -18,10 +18,10 @@ const cl = classNameFactory("vc-spotify-lyrics-");
 let currentLyricIndex: Number | null = null;
 let setCurrentLyricIndex: Function;
 
-function MusicNote() {
+function MusicNote(active: boolean = true) {
     return (
-        <div className={cl("music-note")}>
-            <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#e8eaed">
+        <div className={cl("music-note", !active && "music-note-muted")}>
+            <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="currentColor">
                 <path d="M400-120q-66 0-113-47t-47-113q0-66 47-113t113-47q23 0 42.5 5.5T480-418v-422h240v160H560v400q0 66-47 113t-113 47Z" />
             </svg>
         </div>
@@ -79,7 +79,7 @@ function LyricsDisplay() {
         return (
             <div className="vc-spotify-lyrics">
                 <TooltipContainer text="No synced lyrics found">
-                    {MusicNote()}
+                    {MusicNote(false)}
                 </TooltipContainer>
             </div>
         );
@@ -198,7 +198,7 @@ export function LyricsModal({ rootProps, track, lyrics }: { rootProps: ModalProp
                             selectable
                             className={currentLyricIndex === i ? cl("modal-line-current") : cl("modal-line")}
                         >
-                            {line.lrcTime} {line.text}
+                            <span className={cl("modal-timestamp")}>{line.lrcTime}</span> {line.text}
                         </Text>
                     ))}
                 </div>

--- a/lyrics.tsx
+++ b/lyrics.tsx
@@ -11,6 +11,7 @@ import { ModalContent, ModalHeader, ModalProps, ModalRoot, openModal } from "@ut
 import { Forms, Text, TooltipContainer, useEffect, useState, useStateFromStores } from "@webpack/common";
 import { SpotifyStore, Track } from "plugins/spotifyControls/SpotifyStore";
 
+import { settings } from ".";
 import { getLyrics, SyncedLyrics } from "./api";
 
 const cl = classNameFactory("vc-spotify-lyrics-");
@@ -18,10 +19,10 @@ const cl = classNameFactory("vc-spotify-lyrics-");
 let currentLyricIndex: Number | null = null;
 let setCurrentLyricIndex: Function;
 
-function MusicNote(active: boolean = true) {
+function MusicNote() {
     return (
-        <div className={cl("music-note", !active && "music-note-muted")}>
-            <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="currentColor">
+        <div className={cl("music-note")}>
+            <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="var(--text-muted)">
                 <path d="M400-120q-66 0-113-47t-47-113q0-66 47-113t113-47q23 0 42.5 5.5T480-418v-422h240v160H560v400q0 66-47 113t-113 47Z" />
             </svg>
         </div>
@@ -31,6 +32,7 @@ function MusicNote(active: boolean = true) {
 function LyricsDisplay() {
     const track = SpotifyStore.track!;
 
+    const { ShowMusicNoteOnNoLyrics } = settings.use(["ShowMusicNoteOnNoLyrics"]);
     const [lyrics, setLyrics] = useState<SyncedLyrics[] | null>(null);
     const [currentLyric, setCurrentLyric] = useState<SyncedLyrics | null>(null);
     const [previousLyric, setPreviousLyric] = useState<SyncedLyrics | null>(null);
@@ -76,10 +78,10 @@ function LyricsDisplay() {
     ));
 
     if (!lyrics) {
-        return (
+        return (ShowMusicNoteOnNoLyrics) && (
             <div className="vc-spotify-lyrics">
                 <TooltipContainer text="No synced lyrics found">
-                    {MusicNote(false)}
+                    {MusicNote()}
                 </TooltipContainer>
             </div>
         );

--- a/styles.css
+++ b/styles.css
@@ -8,7 +8,6 @@
     font-size: 16px;
     text-align: center;
     animation: side-to-side 2s ease-in-out infinite;
-    color: var(--text-normal);
 }
 
 @keyframes side-to-side {

--- a/styles.css
+++ b/styles.css
@@ -7,16 +7,11 @@
 .vc-spotify-lyrics-music-note {
     font-size: 16px;
     text-align: center;
-    animation: move-up-down 2s ease-in-out infinite;
-    color: var(--text-normal)
+    animation: side-to-side 2s ease-in-out infinite;
+    color: var(--text-normal);
 }
 
-.vc-spotify-lyrics-music-note-muted {
-    color: var(--text-muted);
-    animation: none;
-}
-
-@keyframes move-up-down {
+@keyframes side-to-side {
     0%,
     100% {
         transform: translateX(0);

--- a/styles.css
+++ b/styles.css
@@ -8,6 +8,12 @@
     font-size: 16px;
     text-align: center;
     animation: move-up-down 2s ease-in-out infinite;
+    color: var(--text-normal)
+}
+
+.vc-spotify-lyrics-music-note-muted {
+    color: var(--text-muted);
+    animation: none;
 }
 
 @keyframes move-up-down {
@@ -51,4 +57,8 @@
 
 .vc-spotify-lyrics-modal-line-current {
     font-weight: bold;
+}
+
+.vc-spotify-lyrics-modal-timestamp {
+    color: var(--text-muted);
 }


### PR DESCRIPTION
Timestamps appear dimmer than lyrics for easier readability
![image](https://github.com/user-attachments/assets/7b7d2711-e6a5-4249-98cd-d01cd2bb8383)

When no lyrics are found the note will be made dimmer and stop animating
![image](https://github.com/user-attachments/assets/b31d542a-a876-4ccc-85bd-c7af604b0375)
