### PR TITLE
Show note in instrumental sections inside modal

### DIFF
--- a/lyrics.tsx
+++ b/lyrics.tsx
@@ -76,13 +76,13 @@ function LyricsDisplay() {
     ));
 
     if (!lyrics) {
-        return (ShowMusicNoteOnNoLyrics) && (
+        return ShowMusicNoteOnNoLyrics ? (
             <div className="vc-spotify-lyrics">
                 <TooltipContainer text="No synced lyrics found">
                     {NoteSvg(cl("music-note"))}
                 </TooltipContainer>
             </div>
-        );
+        ) : null;
     }
 
     return (

--- a/lyrics.tsx
+++ b/lyrics.tsx
@@ -19,13 +19,11 @@ const cl = classNameFactory("vc-spotify-lyrics-");
 let currentLyricIndex: Number | null = null;
 let setCurrentLyricIndex: Function;
 
-function MusicNote() {
+function NoteSvg(className?: string | undefined) {
     return (
-        <div className={cl("music-note")}>
-            <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="var(--text-muted)">
-                <path d="M400-120q-66 0-113-47t-47-113q0-66 47-113t113-47q23 0 42.5 5.5T480-418v-422h240v160H560v400q0 66-47 113t-113 47Z" />
-            </svg>
-        </div>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 480 720" fill="currentColor" className={className}>
+            <path d="m160,-240 q -66,0 -113,-47 -47,-47 -47,-113 0,-66 47,-113 47,-47 113,-47 23,0 42.5,5.5 19.5,5.5 37.5,16.5 v -422 h 240 v 160 H 320 v 400 q 0,66 -47,113 -47,47 -113,47 z" />
+        </svg>
     );
 }
 
@@ -81,7 +79,7 @@ function LyricsDisplay() {
         return (ShowMusicNoteOnNoLyrics) && (
             <div className="vc-spotify-lyrics">
                 <TooltipContainer text="No synced lyrics found">
-                    {MusicNote()}
+                    {NoteSvg(cl("music-note"))}
                 </TooltipContainer>
             </div>
         );
@@ -106,7 +104,7 @@ function LyricsDisplay() {
                     {currentLyric.text}
                 </Text>
             ) : (
-                MusicNote()
+                NoteSvg(cl("music-note"))
             )}
             {nextLyric && (
                 <Text variant="text-xs/normal" className={cl("next")}>
@@ -200,7 +198,7 @@ export function LyricsModal({ rootProps, track, lyrics }: { rootProps: ModalProp
                             selectable
                             className={currentLyricIndex === i ? cl("modal-line-current") : cl("modal-line")}
                         >
-                            <span className={cl("modal-timestamp")}>{line.lrcTime}</span> {line.text}
+                            <span className={cl("modal-timestamp")}>{line.lrcTime}</span>{line.text || NoteSvg(cl("modal-note"))}
                         </Text>
                     ))}
                 </div>

--- a/lyrics.tsx
+++ b/lyrics.tsx
@@ -19,7 +19,7 @@ const cl = classNameFactory("vc-spotify-lyrics-");
 let currentLyricIndex: Number | null = null;
 let setCurrentLyricIndex: Function;
 
-function NoteSvg(className?: string | undefined) {
+function NoteSvg(className: string) {
     return (
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 480 720" fill="currentColor" className={className}>
             <path d="m160,-240 q -66,0 -113,-47 -47,-47 -47,-113 0,-66 47,-113 47,-47 113,-47 23,0 42.5,5.5 19.5,5.5 37.5,16.5 v -422 h 240 v 160 H 320 v 400 q 0,66 -47,113 -47,47 -113,47 z" />
@@ -76,13 +76,13 @@ function LyricsDisplay() {
     ));
 
     if (!lyrics) {
-        return ShowMusicNoteOnNoLyrics ? (
+        return ShowMusicNoteOnNoLyrics && (
             <div className="vc-spotify-lyrics">
                 <TooltipContainer text="No synced lyrics found">
                     {NoteSvg(cl("music-note"))}
                 </TooltipContainer>
             </div>
-        ) : null;
+        );
     }
 
     return (

--- a/styles.css
+++ b/styles.css
@@ -56,8 +56,6 @@
 .vc-spotify-lyrics-modal-note {
     height: 1lh;
     position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
 }
 
 .vc-spotify-lyrics-modal-line-current {

--- a/styles.css
+++ b/styles.css
@@ -8,6 +8,9 @@
     font-size: 16px;
     text-align: center;
     animation: side-to-side 2s ease-in-out infinite;
+    color: var(--text-muted);
+    height: 18px;
+    margin: 3px;
 }
 
 @keyframes side-to-side {
@@ -47,6 +50,14 @@
 .vc-spotify-lyrics-modal-line {
     margin: 4px 0;
     padding: 4px 8px;
+    position: relative;
+}
+
+.vc-spotify-lyrics-modal-note {
+    height: 1lh;
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
 }
 
 .vc-spotify-lyrics-modal-line-current {
@@ -55,4 +66,5 @@
 
 .vc-spotify-lyrics-modal-timestamp {
     color: var(--text-muted);
+    margin-right: 0.5em;
 }


### PR DESCRIPTION
Shows the note icon in places where no lyrics are specified (instrumental sections). 
Also modifies the spacing between timestamps and lyrics to use a 0.5em margin instead of a space.
The edits made to the SVG are just to remove the baked-in padding for easier alignment. I've tested that it looks the same everywhere.

Before
![Before](https://github.com/user-attachments/assets/a353dccb-338a-4140-9680-c3c890ae9289)
After
![After](https://github.com/user-attachments/assets/c50cd382-ff9d-4fa1-b593-187f83aea0d1)

It might be worth also checking if the lyrics are equal to `"..."` since I've also seen that used to annotate instrumental sections.
