### PR TITLE
Fix spotifyControls imports for new vencord version

### DIFF
--- a/api.tsx
+++ b/api.tsx
@@ -6,7 +6,7 @@
 
 import { DataStore } from "@api/index";
 import { hash as h64 } from "@intrnl/xxhash64";
-import { Track } from "plugins/spotifyControls/SpotifyStore";
+import { Track } from "@plugins/spotifyControls/SpotifyStore";
 
 import { getLyricsLrclib } from "./providers/lrclibAPI";
 import { getLyricsSpotify } from "./providers/SpotifyAPI";

--- a/components/lyrics.tsx
+++ b/components/lyrics.tsx
@@ -7,7 +7,7 @@
 import { Paragraph } from "@components/Paragraph";
 import { openModal } from "@utils/modal";
 import { ContextMenuApi, React, Tooltip, useEffect, useState, useStateFromStores } from "@webpack/common";
-import { SpotifyStore } from "plugins/spotifyControls/SpotifyStore";
+import { SpotifyStore } from "@plugins/spotifyControls/SpotifyStore";
 
 import { SpotifyLrcStore } from "../providers/store";
 import settings from "../settings";

--- a/components/modal.tsx
+++ b/components/modal.tsx
@@ -8,7 +8,7 @@ import { Paragraph } from "@components/index";
 import { openImageModal } from "@utils/discord";
 import { ModalContent, ModalHeader, ModalProps, ModalRoot } from "@utils/modal";
 import { React } from "@webpack/common";
-import { SpotifyStore, Track } from "plugins/spotifyControls/SpotifyStore";
+import { SpotifyStore, Track } from "@plugins/spotifyControls/SpotifyStore";
 
 import { SyncedLyric } from "../providers/types";
 import { cl, formatTime, NoteSvg, scrollClasses, useLyrics } from "./util";

--- a/components/util.tsx
+++ b/components/util.tsx
@@ -8,7 +8,7 @@ import { classNameFactory } from "@utils/css";
 import { isNonNullish } from "@utils/guards";
 import { findCssClassesLazy } from "@webpack";
 import { React, useEffect, useMemo, useState, useStateFromStores } from "@webpack/common";
-import { SpotifyStore } from "plugins/spotifyControls/SpotifyStore";
+import { SpotifyStore } from "@plugins/spotifyControls/SpotifyStore";
 
 import { SpotifyLrcStore } from "../providers/store";
 import { SyncedLyric } from "../providers/types";

--- a/index.tsx
+++ b/index.tsx
@@ -10,7 +10,7 @@ import { Settings } from "@api/Settings";
 import ErrorBoundary from "@components/ErrorBoundary";
 import { Devs } from "@utils/constants";
 import definePlugin from "@utils/types";
-import { Player } from "plugins/spotifyControls/PlayerComponent";
+import { Player } from "@plugins/spotifyControls/PlayerComponent";
 
 import { migrateOldLyrics } from "./api";
 import { Lyrics } from "./components/lyrics";

--- a/providers/lrclibAPI/index.ts
+++ b/providers/lrclibAPI/index.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-import type { Track } from "plugins/spotifyControls/SpotifyStore";
+import type { Track } from "@plugins/spotifyControls/SpotifyStore";
 
 import type { SyncedLyric } from "../types";
 

--- a/providers/store.ts
+++ b/providers/store.ts
@@ -7,7 +7,7 @@
 import { showNotification } from "@api/Notifications";
 import { proxyLazyWebpack } from "@webpack";
 import { Flux, FluxDispatcher } from "@webpack/common";
-import { SpotifyStore, type Track } from "plugins/spotifyControls/SpotifyStore";
+import { SpotifyStore, type Track } from "@plugins/spotifyControls/SpotifyStore";
 
 import { getLyrics, identifyTrack, lyricFetchers, providers, updateLyrics } from "../api";
 import settings from "../settings";


### PR DESCRIPTION
Makes the plugin build again on the newest vencord version

Imports are no longer relative to `src`. We should use `@plugin/*` instead of `plugin/*`
Breaking change: https://github.com/Vendicated/Vencord/commit/e836846a2e8b0ef1e89e9a66ab84f2b506caf23a#diff-b55cdbef4907b7045f32cc5360d48d262cca5f94062e353089f189f4460039e0L23